### PR TITLE
Advanced search can now search on title and review word (suboptimally)

### DIFF
--- a/src/components/advancedpopup.js
+++ b/src/components/advancedpopup.js
@@ -28,7 +28,7 @@ export default function AdvancedPopup() {
     const [movieposts, setMoviePosts] = React.useState([]);
     const [reviewposts, setReviewPosts] = React.useState([]);
     const [open, setOpen] = React.useState(false);
-    const [textValues, setTextValues] = React.useState(["", ""]);
+    const [textValues, setTextValues] = React.useState([null, null]);
     const [contentRating, setContentRating] = React.useState(
         Array.from({ length: 7 }, () => false)
     );
@@ -47,7 +47,7 @@ export default function AdvancedPopup() {
     };
 
     const handleReset = () => {
-        setTextValues(["", ""]);
+        setTextValues([null, null]);
         setContentRating(Array.from({ length: 7 }, () => false));
         setGenre(Array.from({ length: 6 }, () => false));
         setMinValue(0);
@@ -80,7 +80,9 @@ export default function AdvancedPopup() {
 
     const handleSubmit = async () => {
         let formInfo = {
-            movieTitle: null
+            movieTitle: textValues[0],
+            reviewBody: textValues[1],
+            reviewTitle: textValues[1]      //ISSUE HERE: if we pass this in for both, then it needs that word present in both the title and the body
         };
         try {
             await client.post('Movies/advanced-search', formInfo)


### PR DESCRIPTION
1. if we put in a review keyword it has to be present in both review body and review title which is not ideal
2. its really slow if you only search review criteria because you would need to search reviews first then movies and i cant figure out how to get 3 unique reviews per movie id. so i just do a request with a large size. sorry.
3. for some reason if you submit a completely null form into the advanced search route, it returns Morbius, Pulp Fiction, and Joker. i don't know why. it honestly astounds me. i could understand if all or none showed up. but just those 3????